### PR TITLE
Fix assertion error

### DIFF
--- a/addon/components/collapsable-facet/component.js
+++ b/addon/components/collapsable-facet/component.js
@@ -14,6 +14,9 @@ export default Ember.Component.extend({
 
     return "";
   }),
+  facetObserver: Ember.observer('facet', function () {
+    this.get('facetChanged')(this.get('facet'));
+  }),
 
   actions: {
     toggleCollapse() {

--- a/addon/components/multi-faceted-search/component.js
+++ b/addon/components/multi-faceted-search/component.js
@@ -63,6 +63,10 @@ export default Ember.Component.extend({
           this.get('removeFacet')(facet.get('category'), term);
         }
       }
+    },
+    facetChanged(index, facet) {
+      this.get('facets')[index] = facet;
+      this.notifyPropertyChange('facets');
     }
   }
 });

--- a/addon/components/multi-faceted-search/template.hbs
+++ b/addon/components/multi-faceted-search/template.hbs
@@ -12,7 +12,7 @@
     </div>
   {{/unless}}
   {{#each facets as |facet index|}}
-    {{collapsable-facet facet=(mut facet) initOpen=(if index false true) toggleFacet=(action "toggleFacet") options=options.facets}}
+    {{collapsable-facet facet=facet initOpen=(if index false true) toggleFacet=(action "toggleFacet") facetChanged=(action "facetChanged" index) options=options.facets}}
   {{/each}}
 </div>
 <div class="{{options.dataWrapperClass}}">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-multi-faceted-search",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Ember CLI addon that provides a multi-faceted search architecture and views for a data set.",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
using `mut` helper with a value derived from another helper results in assertion error "Assertion Failed: You can only pass a path to mut".
looks like the issue could have been fixed by simply removing `mut` from  `addon/components/multi-faceted-search/template.hbs:15`: `collapsable-facet` only updates checked state and there's `toggleFacet` for that. But i tried to kind of save the originally intended behavior and update parent's attribute.